### PR TITLE
fix: title should have default value when build doc

### DIFF
--- a/src/docs-builder.ts
+++ b/src/docs-builder.ts
@@ -119,7 +119,7 @@ interface Doc {
 
 const buildDoc = (mdDoc: MdIndexDoc, id: string): Doc => {
   let m, t;
-  let a = mdDoc.anchor;
+  let a = t = mdDoc.anchor;
   if ((m = /\{(.*?)\}/m.exec(mdDoc.anchor)) !== null) {
     a = m[0];
     t = mdDoc.anchor.replace(/\{(.*?)\}/m, "");
@@ -131,20 +131,13 @@ const buildDoc = (mdDoc: MdIndexDoc, id: string): Doc => {
 
   if (!id.includes(".0")) link += `#${slugify(a)}`;
 
-  return t
-    ? {
-        id,
-        link,
-        b: mdDoc.content,
-        a,
-        t,
-      }
-    : {
-        id,
-        link,
-        b: mdDoc.content,
-        a,
-      };
+  return {
+    id,
+    link,
+    b: mdDoc.content,
+    a,
+    t,
+  };
 };
 
 const buildDocs = async (HTML_FOLDER: string, options: Options) => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50228788/222772546-6f74a403-04aa-43fa-864c-902e8c5801da.png)

Here the bug is, while building markdown block which title has special symbol and no custom anchor followed (also the /\{.*?\}/), the title ( also named variable t in code), will not assigned by the statement clause, and will not get a value. 

As a result, while searching in the docsite, the searched items's title is slugged unexpectedly. (the blue backgrounded item)

But to meet the expect, should not slug the title. (like the red bordered item)
