### PR TITLE
fix(types): fix package.json exports for node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "import": "./dist/vitepress-plugin-search.es.mjs",
-      "require": "./dist/vitepress-plugin-search.umd.js"
+      "require": "./dist/vitepress-plugin-search.umd.js",
+      "types": "./dist/types/src/index.d.ts"
     },
     "./Search.vue": "./dist/Search.vue"
   },


### PR DESCRIPTION
When using TypeScript's new `nodenext`/`node16` `module` setting, and using the new `exports` field in the `package.json` file, TypeScript no longer looks at the root `types` field for looking for type declarations.

Instead, you also need to add a `types` field within the `exports` field. The old `types` field should be kept for compatibility with older TypeScript versions.

See [TypeScript docs on ECMAScript Modules in Node.js][1].

[1]: https://www.typescriptlang.org/docs/handbook/esm-node.html

**Example (copied from TypeScript docs)** at https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing:

> ```json5
> // package.json
> {
>     "name": "my-package",
>     "type": "module",
>     "exports": {
>         ".": {
>             // Entry-point for TypeScript resolution - must occur first!
>             "types": "./types/index.d.ts",
>             // Entry-point for `import "my-package"` in ESM
>             "import": "./esm/index.js",
>             // Entry-point for `require("my-package") in CJS
>             "require": "./commonjs/index.cjs",
>         },
>     },
>     // CJS fall-back for older versions of Node.js
>     "main": "./commonjs/index.cjs",
>     // Fall-back for older versions of TypeScript
>     "types": "./types/index.d.ts"
> }
> ```