### PR TITLE
docs(deps): remove `markdown-it` as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Uses [flexsearch](https://github.com/nextapps-de/flexsearch).
 ## Installing
 
 ```js
-npm i vitepress-plugin-search markdown-it flexsearch -D
+npm i vitepress-plugin-search flexsearch -D
 ```
 
 ## Add the plugin


### PR DESCRIPTION
Hi there,

in my opinion  `markdown-it` is direct dependency of `vitepress-plugin-search` and does not need to be imported as `devDependency`. Or do I miss a point?

Great work, anyway! 🌹