### PR TITLE
fix: move types condition to the first

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "module": "./dist/vitepress-plugin-search.es.mjs",
   "exports": {
     ".": {
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/vitepress-plugin-search.es.mjs",
-      "require": "./dist/vitepress-plugin-search.umd.js",
-      "types": "./dist/types/src/index.d.ts"
+      "require": "./dist/vitepress-plugin-search.umd.js"
     },
     "./Search.vue": "./dist/Search.vue"
   },


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/esm-node.html
> The "types" condition should always come first in "exports".